### PR TITLE
fix error

### DIFF
--- a/Turbosms.php
+++ b/Turbosms.php
@@ -245,7 +245,7 @@ class Turbosms extends Component
             'text' => $text
         ]);
 
-        if (!empty($result->SendSMSResult->ResultArray[1])) {
+        if (is_array($result->SendSMSResult->ResultArray) && !empty($result->SendSMSResult->ResultArray[1])) {
             $this->lastSendMessageId = $result->SendSMSResult->ResultArray[1];
         }
 


### PR DESCRIPTION
при помилці (наприклад в альфаімені) 
$result->SendSMSResult->ResultArray[1] вертається  значення, що не може зберегтися в базу  та викликає 500 на сервері
